### PR TITLE
update app links hideTimeline from component

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/hooks/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/hooks/constants.ts
@@ -18,5 +18,4 @@ export const URL_PARAM_KEY = {
   timerange: 'timerange',
   pageFilter: 'pageFilters',
   rulesTable: 'rulesTable',
-  hideTimeline: 'hideTimeline',
 } as const;

--- a/x-pack/solutions/security/plugins/security_solution/public/common/hooks/timeline/use_init_timeline_url_param.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/hooks/timeline/use_init_timeline_url_param.ts
@@ -62,7 +62,6 @@ export const useInitTimelineFromUrlParam = () => {
   }, [onInitialize, activeTimeline]);
 
   useInitializeUrlParam(URL_PARAM_KEY.timeline, onInitialize);
-  useInitializeUrlParam(URL_PARAM_KEY.hideTimeline, () => {}); // No action needed for hideTimeline, the logic is handled by useShowTimeline hook
 };
 
 function hasTimelineStateChanged(

--- a/x-pack/solutions/security/plugins/security_solution/public/common/utils/timeline/use_show_timeline.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/utils/timeline/use_show_timeline.test.tsx
@@ -127,23 +127,3 @@ describe('Security solution capabilities', () => {
     expect(result.current).toEqual([false]);
   });
 });
-
-describe('hideTimeline URL param', () => {
-  it('should hide timeline when hideTimeline URL param is true', () => {
-    mockUseLocation.mockReturnValueOnce({ pathname: '/overview', search: '?hideTimeline=!t' });
-    const { result } = renderUseShowTimeline();
-    expect(result.current).toEqual([false]);
-  });
-
-  it('should show timeline when hideTimeline URL param is false', () => {
-    mockUseLocation.mockReturnValueOnce({ pathname: '/overview', search: '?hideTimeline=!f' });
-    const { result } = renderUseShowTimeline();
-    expect(result.current).toEqual([true]);
-  });
-
-  it('should show timeline when hideTimeline URL param is not present', () => {
-    mockUseLocation.mockReturnValueOnce({ pathname: '/overview', search: '' });
-    const { result } = renderUseShowTimeline();
-    expect(result.current).toEqual([true]);
-  });
-});

--- a/x-pack/solutions/security/plugins/security_solution/public/common/utils/timeline/use_show_timeline.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/utils/timeline/use_show_timeline.tsx
@@ -9,24 +9,17 @@ import { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useShowTimelineForGivenPath } from './use_show_timeline_for_path';
 import { useUserPrivileges } from '../../components/user_privileges';
-import { getObjectFromQueryString } from '../global_query_string/helpers';
-import { URL_PARAM_KEY } from '../../hooks/constants';
 
 export const useShowTimeline = () => {
-  const { pathname, search } = useLocation();
+  const { pathname } = useLocation();
   const getIsTimelineVisible = useShowTimelineForGivenPath();
   const {
     timelinePrivileges: { read: canSeeTimeline },
   } = useUserPrivileges();
 
-  const hideTimeline = useMemo(
-    () => getObjectFromQueryString<boolean>(URL_PARAM_KEY.hideTimeline, search),
-    [search]
-  );
-
   const showTimeline = useMemo(
-    () => canSeeTimeline && getIsTimelineVisible(pathname) && !hideTimeline,
-    [canSeeTimeline, getIsTimelineVisible, pathname, hideTimeline]
+    () => canSeeTimeline && getIsTimelineVisible(pathname),
+    [pathname, canSeeTimeline, getIsTimelineVisible]
   );
   return [showTimeline];
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_privileged_user_monitoring_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_privileged_user_monitoring_page.tsx
@@ -39,8 +39,7 @@ import { usePrivilegedMonitoringEngineStatus } from '../api/hooks/use_privileged
 import { PrivilegedUserMonitoringManageDataSources } from '../components/privileged_user_monitoring_manage_data_sources';
 import { EmptyPrompt } from '../../common/components/empty_prompt';
 import { useDataView } from '../../data_view_manager/hooks/use_data_view';
-import { useUpdateUrlParam } from '../../common/utils/global_query_string';
-import { URL_PARAM_KEY } from '../../common/hooks/constants';
+import { useUpdateLinkConfig } from '../../common/links/links_hooks';
 
 type PageState =
   | { type: 'fetchingEngineStatus' }
@@ -101,7 +100,6 @@ function reducer(state: PageState, action: Action): PageState {
 }
 
 export const EntityAnalyticsPrivilegedUserMonitoringPage = () => {
-  const hideTimeline = useUpdateUrlParam<boolean>(URL_PARAM_KEY.hideTimeline);
   const { initPrivilegedMonitoringEngine } = useEntityAnalyticsRoutes();
   const [state, dispatch] = useReducer(reducer, initialState);
 
@@ -179,10 +177,16 @@ export const EntityAnalyticsPrivilegedUserMonitoringPage = () => {
     engineStatus.isLoading,
   ]);
 
+  const updateLinkConfig = useUpdateLinkConfig();
+
   // Update UrlParam to add hideTimeline to the URL when the onboarding is loaded and removes it when dashboard is loaded
   useEffect(() => {
-    hideTimeline(['fetchingEngineStatus', 'onboarding', 'initializingEngine'].includes(state.type));
-  }, [state.type, hideTimeline]);
+    const hideTimeline = ['fetchingEngineStatus', 'onboarding', 'initializingEngine'].includes(
+      state.type
+    );
+    // update the hideTimeline property in the link config. This call triggers expensive operations, use with love
+    updateLinkConfig(SecurityPageName.entityAnalyticsPrivilegedUserMonitoring, { hideTimeline });
+  }, [state.type, updateLinkConfig]);
 
   const fullHeightCSS = css`
     min-height: calc(100vh - 240px);


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
